### PR TITLE
Changed tag registration process

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,6 @@ Keep in mind that StackScript is made to be extremely basic and limited, so I mi
 
 ### Things you could help with
 Here are some ideas of what you could work on if you want to contribute to the project but don't know where to start. They should be fairly simple to do but would make great contributions:
-- move the tag registration to the parser, allowing for forward jumps
-- add `jumpLessThan` and `jumpGreaterThan` instructions
 - create a C program to add a better way to run the interpreter. At the moment running a stsc program is a by awkward: `python ./src/stackscript.py path_to_program`. It would be easier if an exe file handled the call to python, so the user could simply run `./stackscript path_to_program`
 - either prove that StackScript is Turing complete or that it is not. Even if it is not Turing complete, it would be great to know.
 - improve the documentation by adding better examples, correcting grammar mistakes/typos and make the explanations clearer.

--- a/examples/compare.stsc
+++ b/examples/compare.stsc
@@ -1,0 +1,13 @@
+// this program takes two user inputs a and b and prints 1.0 is a<b and -1.0 if a>=b
+uInput uInput
+sub -1 mul
+
+aLessThanb jumpNeg
+-1 print // this part is accessed iff a-b>=0 ie a>=b
+end jump
+
+>aLessThanb
+1 print // this part is accessed iff a-b<0 ie a<b
+end jump
+
+>end

--- a/src/stackscript.py
+++ b/src/stackscript.py
@@ -17,5 +17,6 @@ if __name__ == "__main__":
         
     code_parser = Parser()
     code_parser.parse(raw_code)
+    code_parser.register_tags()
     
     Interpreter(code_parser).run()

--- a/src/stsc_interpreter.py
+++ b/src/stsc_interpreter.py
@@ -31,7 +31,7 @@ class Interpreter:
         self.stack = []
         self.instructions = parser.tokens
         self.ip = 0  # instruction pointer
-        self.tags = {}
+        self.tags = parser.tags
         
     def is_number(self, s: str) -> bool:
         return bool(re.match(r'^[-+]?(\d+(\.\d*)?|\.\d+)$', s))
@@ -257,11 +257,8 @@ class Interpreter:
                 instruction_mapping[self.DIV_INSTRUCTION]()
                 
             # Tag and jump instructions
-            elif len(cur_instruction) > 0 and cur_instruction[0] == ">": # found a new tag definition
-                if len(cur_instruction) < 2:
-                    print("tags must have at least one character.")
-                    exit(-1)
-                self.tags[cur_instruction[1:]] = self.ip  # stores the position of the tag
+            elif len(cur_instruction) > 0 and cur_instruction[0] == ">":
+                pass # tags are already registered in stsc_parcer.py
             elif cur_instruction in self.tags:
                 self.stack.append(cur_instruction)
             elif cur_instruction == self.JUMP_INSTRUCTION:

--- a/src/stsc_parser.py
+++ b/src/stsc_parser.py
@@ -10,3 +10,12 @@ class Parser:
             tokens = line.strip().split()
             self.tokens.extend(tokens)
         return self.tokens
+    
+    def register_tags(self) -> dict:
+        if self.tokens == None:
+            raise RuntimeError("Cannot register tag before parsing.")
+        self.tags = {}
+        for ip, token in enumerate(self.tokens):
+            if token[0] == ">": # found a tag
+                self.tags[token[1:]] = ip
+        return self.tags


### PR DESCRIPTION
Tags are now registered in the parser. This ensures that all tags declared in the program are registered before the program is run, allowing for forward jumps. See the example compare.stsc.